### PR TITLE
Fix ASUnicode build error in plugin SDK.

### DIFF
--- a/pluginsdk/samplecode/common/includes/Logger.h
+++ b/pluginsdk/samplecode/common/includes/Logger.h
@@ -6,7 +6,7 @@
 using namespace std;
 
 #ifndef ps_wstring
-typedef basic_string<ASUnicode, char_traits<ASUnicode>, allocator<ASUnicode> > ps_wstring;
+typedef basic_string<char16_t, char_traits<char16_t>, allocator<char16_t> > ps_wstring;
 #endif
 
 #ifndef MAX_PATH

--- a/pluginsdk/samplecode/common/includes/PropertyUtils.h
+++ b/pluginsdk/samplecode/common/includes/PropertyUtils.h
@@ -14,7 +14,7 @@
 
 using namespace std;
 
-typedef basic_string<ASUnicode, char_traits<ASUnicode>, allocator<ASUnicode> > ps_wstring;
+typedef basic_string<char16_t, char_traits<char16_t>, allocator<char16_t> > ps_wstring;
 
 
 enum InterpolationMethod { nearestNeighbor = 1, bilinear, bicubic, bicubicSmoother, bicubicSharper, bicubicAutomatic };

--- a/pluginsdk/samplecode/common/sources/Logger.cpp
+++ b/pluginsdk/samplecode/common/sources/Logger.cpp
@@ -94,7 +94,7 @@ void Logger::Write( vector<ps_wstring> & inValue, const bool endOfLine )
 	while (iter != inValue.end())
 	{
 		ASZString zString;
-		if (!sASZString2->MakeFromUnicode((*iter).c_str(), (*iter).size(), &zString))
+		if (!sASZString2->MakeFromUnicode((ASUnicode*)(*iter).c_str(), (*iter).size(), &zString))
 		{
 			ASUInt32 utf8Size = sASZString2->LengthAsUTF8String(zString);
 			unsigned char * utf8Buffer = new unsigned char[utf8Size];

--- a/pluginsdk/samplecode/filter/propetizer/common/Propetizer.cpp
+++ b/pluginsdk/samplecode/filter/propetizer/common/Propetizer.cpp
@@ -1679,7 +1679,7 @@ OSErr GetLayerNames(vector<ps_wstring> & vs)
 	vs.clear();
 	if (!e && !i)
     {
-        const ASUnicode s[] = {'B','a','c','k','g','r','o','u','n','d',0};
+        const char16_t s[] = {'B','a','c','k','g','r','o','u','n','d',0};
         vs.push_back(s);
     }
 	if (!e)


### PR DESCRIPTION
Fix ASUnicode build error in plugin SDK.

## Description

unsigned short is no longer supported by basic_string, changing it to char16_t

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Fixes the build

## How Has This Been Tested?

Built the plugin on Mac and Windows and made sure it loads in Photoshop.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
